### PR TITLE
👷 ci: Update turbo.json outputs

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -7,7 +7,8 @@
             ],
             "outputs": [
                 ".svelte-kit/**",
-                "dist/**"
+                "dist/**",
+                ".vercel/**"
             ],
             "env": [
                 "DATABASE_URL"


### PR DESCRIPTION
Sometimes vercel build fails, maybe cause because we dont include its outputs