### PR TITLE
🐛 fix: Recover from image not found errors

### DIFF
--- a/app/src/components/RecipeItem.svelte
+++ b/app/src/components/RecipeItem.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { handleImageError } from '$lib/client/handleImageError';
 	import { NOT_FOUND_IMAGE } from '$lib/common/constants';
 	import { INGREDIENTS } from '$lib/common/ingredients';
 	import type { Recipe as RecipeEntity } from '$lib/db/types';
@@ -67,6 +68,7 @@
 			class={imgProps?.class}
 			alt={recipe.name}
 			src={recipe.imageUrl ?? NOT_FOUND_IMAGE}
+			onerror={handleImageError}
 		/>
 
 		<h3 class="mt-1 text-center text-sm font-bold xxs:text-base xs:text-lg">

--- a/app/src/lib/client/handleImageError.ts
+++ b/app/src/lib/client/handleImageError.ts
@@ -1,0 +1,15 @@
+import { NOT_FOUND_IMAGE } from '$lib/common/constants';
+
+/**
+ * A handle to recover from image loading errors
+ */
+export function handleImageError(ev: Event) {
+	const img = ev.currentTarget as HTMLImageElement;
+
+	if (!(img instanceof HTMLImageElement)) {
+		console.warn("'handleImageError' must be used in an HTMLImageElement");
+		return;
+	}
+
+	img.src = NOT_FOUND_IMAGE;
+}

--- a/app/src/routes/recipes/[recipe_id]/+page.svelte
+++ b/app/src/routes/recipes/[recipe_id]/+page.svelte
@@ -7,6 +7,7 @@
 	import DeleteRecipeButton from './DeleteRecipeButton.svelte';
 	import { NOT_FOUND_IMAGE } from '$lib/common/constants';
 	import { relativeTime } from '$lib/hooks/relativeTime.svelte';
+	import { handleImageError } from '$lib/client/handleImageError';
 
 	let { data }: { data: PageData } = $props();
 
@@ -63,6 +64,7 @@
 							alt={recipe.name}
 							class="mx-auto aspect-square overflow-hidden rounded-xl object-cover"
 							style={`view-transition-name: recipe-${recipe.id}`}
+							onerror={handleImageError}
 						/>
 						{#if isCurrentUserRecipe}
 							<div class="flex w-full flex-row gap-2">


### PR DESCRIPTION
When an image is not found, we show the ugly browser default, so instead we handle the error and show the default