### PR TITLE
🐛 fix: Infinite scrolling in explore

### DIFF
--- a/app/src/routes/my-recipes/+page.svelte
+++ b/app/src/routes/my-recipes/+page.svelte
@@ -25,7 +25,7 @@
 
 	{#if hasRecipes}
 		<div
-			class="grid grid-cols-1 flex-wrap justify-center gap-4 py-5 xs:grid-cols-2 md:grid-cols-3 xl:grid-cols-4"
+			class="xxs:grid-cols-2 xs:grid-cols-3 grid grid-cols-1 flex-wrap justify-center gap-4 py-5 md:grid-cols-4 xl:grid-cols-5"
 		>
 			{#each recipes as recipe, index}
 				<RecipeItem {recipe} {index} imgProps={{ width: 400, height: 400 }} />

--- a/app/src/routes/my-recipes/+page.svelte
+++ b/app/src/routes/my-recipes/+page.svelte
@@ -25,7 +25,7 @@
 
 	{#if hasRecipes}
 		<div
-			class="xxs:grid-cols-2 xs:grid-cols-3 grid grid-cols-1 flex-wrap justify-center gap-4 py-5 md:grid-cols-4 xl:grid-cols-5"
+			class="grid grid-cols-1 flex-wrap justify-center gap-4 py-5 xxs:grid-cols-2 xs:grid-cols-3 md:grid-cols-4 xl:grid-cols-5"
 		>
 			{#each recipes as recipe, index}
 				<RecipeItem {recipe} {index} imgProps={{ width: 400, height: 400 }} />


### PR DESCRIPTION
The infinite scrolling was skipping some results, and the grid in my-recipes was too big on small devices