### PR TITLE
🐛 fix: Remove base SEO image

### DIFF
--- a/app/src/routes/+layout.svelte
+++ b/app/src/routes/+layout.svelte
@@ -60,15 +60,7 @@
 	setSeoBaseTitle(`CocinarIA ${icon}`);
 </script>
 
-<SvelteSeo
-	openGraph={{
-		images: [
-			{
-				url: data.seo.image
-			}
-		]
-	}}
-/>
+<SvelteSeo />
 
 <svelte:head>
 	<title>{`CocinarIA ${icon}`}</title>

--- a/app/src/routes/+page.svelte
+++ b/app/src/routes/+page.svelte
@@ -16,6 +16,13 @@
 
 <SvelteSeo
 	description={`Discover delicious recipes tailored to your taste with this AI-powered recipe generator. Specify the recipe type and ingredients, and get detailed steps, precise ingredient amounts, and images. Whether you're a seasoned chef or a home cook, enjoy a variety of culinary inspirations and create mouth-watering dishes with ease.`}
+	openGraph={{
+		images: [
+			{
+				url: data.seo.image
+			}
+		]
+	}}
 />
 
 <section


### PR DESCRIPTION
The base seo image is overriding the recipes seo image, we remove it for now